### PR TITLE
Depth & production options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Courtesy of [yargs](https://www.npmjs.com/packages/yargs):
       -q, --quiet       Don't output anything.                                                                                         [boolean]
       -v, --verbose     Detailed list of package licenses.                                                                             [boolean]
       --dir             Base directory of package to validate. Defaults to current working directory.
+      -d, --depth       How deep to traverse packages where 0 is the current package.json only.                                     [default: 1]
+      -p, --production  Only traverse dependencies, no dev-dependencies.                                              [boolean] [default: false]
       --allow-licenses  A list of licenses to allow. Validation will fail if a package is present that is not licensed under any of the licenses
                         in this list.                                                                                                    [array]
       --allow-packages  A list of packages to allow. Can be used to allow packages for which the license is not detected correctly (can happen

--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,13 @@ var yargs = require('yargs')
     .describe('v', 'Detailed list of package licenses.')
     .nargs('dir', 1)
     .describe('dir', 'Base directory of package to validate. Defaults to current working directory.')
+    .default('d', 1)
+    .alias('d', 'depth')
+    .describe('d', 'How deep to traverse packages where 0 is the current package.json only.')
+    .boolean('production')
+    .alias('p', 'production')
+    .default('p', false)
+    .describe('p', 'Only traverse dependencies, no dev-dependencies.')
     .array('allow-licenses')
     .describe('allow-licenses', 'A list of licenses to allow. Validation will fail if a package is present that is not licensed under any of the licenses in this list.')
     .array('allow-packages')
@@ -49,7 +56,9 @@ function stringsort(a, b) {
 
 require('./index')(DIR, {
     licenses: argv['allow-licenses'] || [ ],
-    packages: argv['allow-packages'] || [ ]
+    packages: argv['allow-packages'] || [ ],
+    depth: argv['depth'],
+    production: argv['production']
 }, function (err, res) {
     if (err) {
         console.error('\nError: %s\n', err.message);

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function (rootDir, opts, cb) {
     
     nlf.find({
         directory: rootDir,
-        depth: typeof opts.depth === 'undefined' ? 1 : opts.depth,
+        depth: typeof opts.depth === 'undefined' ? 0 : opts.depth,
         production: typeof opts.production === 'undefined' ? false : opts.production
     }, function (err, data) {
         if (err) { cb(err); return; }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ module.exports = function (rootDir, opts, cb) {
     
     nlf.find({
         directory: rootDir,
-        depth: 0
+        depth: typeof opts.depth === 'undefined' ? 1 : opts.depth,
+        production: typeof opts.production === 'undefined' ? false : opts.production
     }, function (err, data) {
         if (err) { cb(err); return; }
         


### PR DESCRIPTION
Added flags that can be passed to `nlf` while retaining the same default values as `nlv`. Depth allows scanning the entire dependency tree and production ignores devDependencies.
