### PR TITLE
Use spdx-satisfies and spdx-expression-validate

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 var fs = require('fs'),
     npa = require('npm-package-arg'),
-    spdx = require('spdx'),
+    satisfies = require('spdx-satisfies'),
+    validate = require('spdx-expression-validate'),
     semver = require('semver'),
     format = require('util').format;
 
@@ -71,7 +72,7 @@ module.exports = function (rootDir, opts, cb) {
     // we build a string like (MIT OR ISC OR JSON OR BSD-3-Clause) with all the licenses
     // we have deemed acceptable; if a package has an 'AND' specification, it will validate
     // correctly as long as we specify both parts
-    var whitelistSPDX = '(' + opts.licenses.filter(spdx.valid).join(' OR ') + ')';
+    var whitelistSPDX = '(' + opts.licenses.filter(validate).join(' OR ') + ')';
     
     var whitelistPackages = opts.packages.reduce(function (acc, cur) {
         var parsed = npa(cur);
@@ -128,7 +129,7 @@ module.exports = function (rootDir, opts, cb) {
                     
                     // if the license from the file is a valid spdx expression,
                     // compare it against our spdx whitelist expression
-                    if (spdx.valid(cur) && spdx.valid(whitelistSPDX) && spdx.satisfies(cur, whitelistSPDX)) {
+                    if (validate(cur) && validate(whitelistSPDX) && satisfies(cur, whitelistSPDX)) {
                         return cur;
                     }
                     

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "nlf": "^1.3.1",
     "npm-package-arg": "^4.0.1",
     "semver": "^4.3.6",
-    "spdx": "^0.4.1",
+    "spdx-expression-validate": "^1.0.1",
+    "spdx-satisfies": "^0.1.3",
     "yargs": "^3.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request replaces `spdx` with `spdx-expression-validate` and `spdx-satisfies`, which were split out from the original `spdx` and remain under active development.

`spdx` was originally a monolithic package encompassing parsing, validation, and ranges, much like `semver`. It's since been split out into smaller packages, with just `spdx-expression-parse` in the dependency tree of npm 0.3.x.
