### PR TITLE
Update all dependency versions; pass tests and lint

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -70,8 +70,8 @@ require('./index')(DIR, {
     licenses: argv['allow-licenses'] || [ ],
     packages: argv['allow-packages'] || [ ],
     listOnly: !!argv['list-licenses'],
-    deep: !!argv['deep'],
-    production: argv['production'],
+    deep: !!argv.deep,
+    production: argv.production,
     warn: warn
 }, function (err, res) {
     if (err) {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ module.exports = function (rootDir, opts, cb) {
         if (acc.hasOwnProperty(pkg)) {
             warn(pkg + ' is specified more than once in allowed packages. Use the SPDX `||` operator to specify multiple versions of a single package.');
         }
+        if (parsed.rawSpec === '') {
+          parsed.spec = '*';
+        }
         acc[pkg] = parsed;
         return acc;
     }, { });
@@ -108,7 +111,7 @@ module.exports = function (rootDir, opts, cb) {
         
         // nlf's return data sucks, and the standard formatter does a lot more than just making it pretty
         // so instead we just call the formatter and parse the return data
-        nlf.standardFormatter.render(data, function (err, output) {
+        nlf.standardFormatter.render(data, {}, function (err, output) {
             if (err) { cb(err); return; }
             
             var re = new RegExp(/(.*?@\d+\.[^ ]+) \[license\(s\): (.*)\]$/mg),

--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
   },
   "homepage": "https://github.com/myndzi/node-license-validator#readme",
   "dependencies": {
-    "nlf": "^1.3.1",
-    "npm-package-arg": "^4.0.1",
+    "nlf": "^1.4.2",
+    "npm-package-arg": "^4.2.0",
     "semver": "^4.3.6",
     "spdx-expression-validate": "^1.0.1",
     "spdx-satisfies": "^0.1.3",
-    "yargs": "^3.27.0"
+    "yargs": "^3.32.0"
   },
   "devDependencies": {
-    "istanbul": "^0.3.17",
-    "jshint": "^2.8.0",
-    "mocha": "^2.2.5",
-    "should": "^7.0.2"
+    "istanbul": "^0.3.22",
+    "jshint": "^2.9.3",
+    "mocha": "^2.5.3",
+    "should": "^7.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ function test(packages, opts, match) {
     opts.__nlf = opts.__nlf || {
         find: function (opts, cb) { cb(null, packages); },
         standardFormatter: {
-            render: function (data, cb) {
+            render: function (data, opts, cb) {
                 var pkgstr = packages.map(function (def) {
                     return format('%s [license(s): %s]', def.pkg, def.licenses.join(', '));
                 }).join('\n');
@@ -302,7 +302,7 @@ describe('NLF-validator', function () {
                 __nlf: {
                     find: function (opts, cb) { cb(null, [ 'foo' ]); },
                     standardFormatter: {
-                        render: function (data, cb) { cb(err); }
+                        render: function (data, opts, cb) { cb(err); }
                     }
                 }
             }, function (_err, res) {


### PR DESCRIPTION
`node-license-validator` is currently broken. This patch updates all dependencies to their latest versions and makes a few tweaks to pass tests + lint with the new versions.
