### PR TITLE
fix: yargs too many arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -43,7 +43,7 @@ var yargs = require('yargs')
     .example(cmd+' ~/project --allow-packages pg@^3.6.0', 'Allow the package \'pg\' (3.6.0 and up, but not 4.0.0 or higher).')
 ;
 
-yargs.wrap(Math.max(140), yargs.terminalWidth());
+yargs.wrap(Math.max(140, yargs.terminalWidth()));
 
 var argv = yargs.argv;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Validate the licenses of your dependencies against a list",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --bail test.js",
+    "test": "mocha --bail test.js test-cli.js",
     "report": "istanbul cover -x test.js -x node_modules node_modules/.bin/_mocha -- -u bdd -R spec --bail test.js;jshint index.js cli.js",
     "lint": "jshint index.js cli.js"
   },

--- a/test-cli-runner.js
+++ b/test-cli-runner.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const spawn = require('child_process').spawn
+
+const platform = require('os').platform()
+const isUnix = platform.includes('win') ? false : true
+
+class Runner {
+    start(binary, args, cwd, env) {
+        return new Promise((resolve, reject) => {
+            let hasError = false;
+            
+            this._process = spawn(binary, args, { windowsHide: true, env, cwd });
+
+            this._process.stdout.on('data', (data) => {
+                console.log('data', data.toString());
+            });
+        
+            this._process.on('exit', () => {
+                if (hasError) {
+                    reject();
+                } else {
+                    resolve();
+                }
+            });
+
+            this._process.stderr.on('data', (data) => {
+                console.log('err', data.toString())
+                hasError = true;
+            });
+
+            process.on('SIGHUP', () => {
+                this.stop();
+            });
+        })
+    }
+
+    _waitForOutputAndCallBack(stream, message, callback) {
+        stream.on('data', function fn(data) {
+            if (data.indexOf(message) >= 0) {
+                stream.removeListener('data', fn)
+                callback()
+            }
+        })
+    }
+
+    stop() {
+        if (isUnix) {
+            return this._stopUnix()
+        } else {
+            return this._stopWin()
+        }
+    }
+
+    _stopUnix() {
+        return new Promise((resolve) => {
+            if (!this._process.killed) {
+                const kill = spawn('kill', [this._process.pid]);
+                kill.on('exit', resolve)
+            }
+        })
+    }
+
+    _stopWin() {
+        return new Promise((resolve, reject) => {
+            if (!this._process.killed) {
+                const kill = spawn("taskkill", ["/pid", this._process.pid, '/f', '/t']);
+                kill.on('exit', resolve)
+            }
+        })
+    }
+}
+
+module.exports = Runner

--- a/test-cli.js
+++ b/test-cli.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Runner = require('./test-cli-runner');
+const runner = new Runner();
+
+describe('CLI', function () {
+
+    it('should validate licenses and don\'t print to stderr', async function () {
+        return runner.start('node', ['cli.js', '--allow-licenses', 'MIT/X11', 'CC0-1.0', 'ISC', 'MIT', 'Apache-2.0', '--production', '--deep']);
+    });
+});


### PR DESCRIPTION
After dependency update `yargs` prints an error to console because `yargs.wrap` is called with 2 arguments instead of only 1. This might be a legacy issue in the lib itself as `Math.max` was only called with one parameter. It _looks_ like paranthesis were not placed correctly.

### Before
`yargs.wrap(Math.max(140), yargs.terminalWidth());`

### After
`yargs.wrap(Math.max(140, yargs.terminalWidth()));`

### Error
```bash
YError: Too many arguments provided. Expected max 1 but received 2.
    at h (C:\workspace\prometheus-ssh-logged-in-users-exporter\node_modules\node-license-validator\node_modules\yargs\build\index.cjs:1:1795)
    at Bt.wrap (C:\workspace\prometheus-ssh-logged-in-users-exporter\node_modules\node-license-validator\node_modules\yargs\build\index.cjs:1:40340)
    at Object.<anonymous> (C:\workspace\prometheus-ssh-logged-in-users-exporter\node_modules\node-license-validator\cli.js:46:7)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47
Identified licenses: Apache-2.0, ISC, MIT
All licenses ok.
```

This error does not break the validation its just printed to the console.