### PR TITLE
Remove node 11 (unsupported by recent yargs)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
 
     steps:
     - name: Git checkout


### PR DESCRIPTION
CLI test shows that node 11.x is unsupported by recent versions of yargs. Just drop it from the tests; if someone needs an old node version, we can pursue an alternative.